### PR TITLE
Lock down chef gem pg version.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url        "https://github.com/clearstorydata/chef-postgresql/issues"
 source_url        "https://github.com/clearstorydata/chef-postgresql"
 description       "Installs and configures postgresql for clients or servers"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "3.5.1014"
+version           "3.5.1015"
 recipe            "postgresql", "Includes postgresql::client"
 recipe            "postgresql::ruby", "Installs pg gem for Ruby bindings"
 recipe            "postgresql::client", "Installs postgresql client package(s)"

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -48,13 +48,15 @@ rescue LoadError
   node['postgresql']['client']['packages'].each do |pg_pack|
     resources("package[#{pg_pack}]").run_action(:install)
   end
-  
+
   package "libpq-dev" do
     action :nothing
   end.run_action(:install)
 
   begin
-    chef_gem "pg"
+    chef_gem "pg" do
+      version "0.21.0"
+    end
   rescue Gem::Installer::ExtensionBuildError, Mixlib::ShellOut::ShellCommandFailed => e
     # Are we an omnibus install?
     raise if RbConfig.ruby.scan(%r{(chef|opscode)}).empty?


### PR DESCRIPTION
The latest version breaks the Database cookbook that we rely on. 